### PR TITLE
Only set err if not set

### DIFF
--- a/putter.go
+++ b/putter.go
@@ -187,7 +187,9 @@ func (p *putter) retryPutPart(part *part) {
 		logger.debugPrintf("Error on attempt %d: Retrying part: %d, Error: %s", i, part.PartNumber, err)
 		time.Sleep(time.Duration(math.Exp2(float64(i))) * 100 * time.Millisecond) // exponential back-off
 	}
-	p.err = err
+	if p.err == nil {
+		p.err = err
+	}
 }
 
 // uploads a part, checking the etag against the calculated value


### PR DESCRIPTION
Since this variable is re-used across the various workers, it might get set to nil unexpectedly in certain scenarios. Perhaps we should only let the first non-nil in win.