### PR TITLE
Retry 500 response if an error does not occur

### DIFF
--- a/getter.go
+++ b/getter.go
@@ -112,15 +112,13 @@ func (g *getter) retryRequest(method, urlStr string, body io.ReadSeeker) (resp *
 
 		g.b.Sign(req)
 		resp, err = g.c.Client.Do(req)
-		if err == nil {
-			return
-		}
-		logger.debugPrintln(err)
-
-		// retry internal server errors after a short delay
-		if resp != nil && resp.StatusCode == 500 {
+		if err == nil && resp.StatusCode == 500 {
+			// retry internal server errors after a short delay
 			time.Sleep(time.Duration(math.Exp2(float64(i))) * 100 * time.Millisecond) // exponential back-off
-			continue
+		} else if err == nil {
+			return
+		} else {
+			logger.debugPrintln(err)
 		}
 
 		if body != nil {

--- a/putter.go
+++ b/putter.go
@@ -383,15 +383,13 @@ func (p *putter) retryRequest(method, urlStr string, body io.ReadSeeker, h http.
 
 		p.b.Sign(req)
 		resp, err = p.c.Client.Do(req)
-		if err == nil {
-			return
-		}
-		logger.debugPrintln(err)
-
-		// retry internal server errors after a short delay
-		if resp != nil && resp.StatusCode == 500 {
+		if err == nil && resp.StatusCode == 500 {
+			// retry internal server errors after a short delay
 			time.Sleep(time.Duration(math.Exp2(float64(i))) * 100 * time.Millisecond) // exponential back-off
-			continue
+		} else if err == nil {
+			return
+		} else {
+			logger.debugPrintln(err)
 		}
 
 		if body != nil {


### PR DESCRIPTION
We want to retry 500 errors if an error _does not_ occur.

Relevant lines from the [go docs](https://golang.org/pkg/net/http/#Client.Do):

> A non-2xx response doesn't cause an error. When err is nil, resp always contains a non-nil resp.Body.