### PR TITLE
Exclude the racy test by default

### DIFF
--- a/pool_test.go
+++ b/pool_test.go
@@ -1,4 +1,4 @@
-// +build !race
+// +build !race,testrace
 
 package s3gof3r
 


### PR DESCRIPTION
This is mainly for CI testing. To run the test, you now have to explicitly specify the "testrace" build tag:

```
go test -tags=testrace
```

Long-term it might be better to re-write this test so it doesn't produce race conditions.

<!---
@huboard:{"custom_state":"archived"}
-->
